### PR TITLE
Add filtered GET endpoints for developers, genres, publishers

### DIFF
--- a/GameLibraryAPI/GameLibrary.Core/Services/DevelopersService.cs
+++ b/GameLibraryAPI/GameLibrary.Core/Services/DevelopersService.cs
@@ -35,6 +35,12 @@ public class DevelopersService(DeveloperRepository devsRepository)
         var result = await devsRepository.GetDeveloperByIdAsync(id);
         return result?.ToResponseDto();
     }
+    
+    public async Task<IEnumerable<GetDeveloperResponse>> GetDeveloperFilteredAsync(string? name = null, string? sortOrder = "asc")
+    {
+        var result = await devsRepository.GetDevelopersFilteredAsync(name, sortOrder);
+        return result.Select(d => d.ToResponseDto()).ToList();
+    }
 
     public async Task SoftDeleteDeveloperAsync(int id)
     {

--- a/GameLibraryAPI/GameLibrary.Core/Services/GenresService.cs
+++ b/GameLibraryAPI/GameLibrary.Core/Services/GenresService.cs
@@ -31,6 +31,12 @@ public class GenresService(GenreRepository genreRepository)
         return (result.Select(g => g.ToResponseDto()).ToList(), total);
     }
 
+    public async Task<IEnumerable<GetGenreResponse>> GetGenresFilteredAsync(string? name = null, string? sortOrder = "asc")
+    {
+        var result = await genreRepository.GetGenresFilteredAsync(name, sortOrder);
+        return result.Select(g => g.ToResponseDto()).ToList();
+    }
+
     public async Task<GetGenreResponse?> GetGenreFromIdAsync(int id)
     {
         var result = await genreRepository.GetGenreByIdAsync(id);

--- a/GameLibraryAPI/GameLibrary.Core/Services/PublisherService.cs
+++ b/GameLibraryAPI/GameLibrary.Core/Services/PublisherService.cs
@@ -31,6 +31,12 @@ public class PublisherService(PublisherRepository publisherRepository)
         return (result.Select(p => p.ToResponseDto()).ToList(), total);
     }
 
+    public async Task<IEnumerable<GetPublisherResponse>> GetPublishersFilteredAsync(string? name = null, string? sortOrder = "asc")
+    {
+        var result = await publisherRepository.GetPublishersFilteredAsync(name, sortOrder);
+        return result.Select(p => p.ToResponseDto()).ToList();
+    }
+
     public async Task<GetPublisherResponse?> GetPublisherFromIdAsync(int id)
     {
         var result = await publisherRepository.GetPublisherByIdAsync(id);

--- a/GameLibraryAPI/GameLibrary.Database/Repositories/DeveloperRepository.cs
+++ b/GameLibraryAPI/GameLibrary.Database/Repositories/DeveloperRepository.cs
@@ -43,9 +43,9 @@ namespace GameLibrary.Database.Repositories
             return (items, totalCount);
         }
 
-        public async Task<IEnumerable<Developer>> GetDevelopersAsync(string? name = null, string? sortOrder = "asc")
+        public async Task<IEnumerable<Developer>> GetDevelopersFilteredAsync(string? name = null, string? sortOrder = "asc")
         {
-            IQueryable<Developer> query = GetRecords().Include(d=>d.Games);
+            IQueryable<Developer> query = GetRecords();
 
             if (!string.IsNullOrEmpty(name))
             {
@@ -56,7 +56,7 @@ namespace GameLibrary.Database.Repositories
                 ? query.OrderByDescending(d => d.Name)
                 : query.OrderBy(d => d.Name);
 
-            return await query.ToListAsync();
+            return await query.Include(d => d.Games).ToListAsync();
         }
 
         public async Task AddDevAsync(Developer entity)

--- a/GameLibraryAPI/GameLibrary.Database/Repositories/GenreRepository.cs
+++ b/GameLibraryAPI/GameLibrary.Database/Repositories/GenreRepository.cs
@@ -41,7 +41,7 @@ namespace GameLibrary.Database.Repositories
             return (items, totalCount);
         }
 
-        public async Task<IEnumerable<Genre>> GetGenresAsync(string? name = null, string? sortOrder = "asc")
+        public async Task<IEnumerable<Genre>> GetGenresFilteredAsync(string? name = null, string? sortOrder = "asc")
         {
             IQueryable<Genre> query = GetRecords().Include(g => g.Games);
 

--- a/GameLibraryAPI/GameLibrary.Database/Repositories/PublisherRepository.cs
+++ b/GameLibraryAPI/GameLibrary.Database/Repositories/PublisherRepository.cs
@@ -36,7 +36,7 @@ namespace GameLibrary.Database.Repositories
             return (publishers, totalCount);
         }
 
-        public async Task<IEnumerable<Publisher>> GetPublishersAsync(string? name = null, string? sortOrder = "asc")
+        public async Task<IEnumerable<Publisher>> GetPublishersFilteredAsync(string? name = null, string? sortOrder = "asc")
         {
             IQueryable<Publisher> query = GetRecords().Include(p => p.Games);
 

--- a/GameLibraryAPI/GameLibraryAPI/Controllers/DeveloperController.cs
+++ b/GameLibraryAPI/GameLibraryAPI/Controllers/DeveloperController.cs
@@ -35,6 +35,13 @@ namespace GameLibrary.Api.Controllers
             });
         }
 
+        [HttpGet("get-developers-filtered")]
+        public async Task<IActionResult> GetDeveloperFilteredAsync([FromQuery] string? name = null, [FromQuery] string? sortOrder = "asc")
+        {
+            var result = await devsService.GetDeveloperFilteredAsync(name, sortOrder);
+            return Ok(result);
+        }
+
         [HttpGet("get-developers-by-{id}")]
         public async Task<IActionResult> GetDeveloperFromIdAsync(int id)
         {

--- a/GameLibraryAPI/GameLibraryAPI/Controllers/GenreController.cs
+++ b/GameLibraryAPI/GameLibraryAPI/Controllers/GenreController.cs
@@ -33,12 +33,22 @@ namespace GameLibrary.Api.Controllers
             });
         }
 
+
+        [HttpGet("get-genres-filtered")]
+        public async Task<IActionResult> GetGenresFilteredAsync([FromQuery] string? name = null, [FromQuery] string? sortOrder = "asc")
+        {
+            var result = await genresService.GetGenresFilteredAsync(name, sortOrder);
+            return Ok(result);
+        }
+
+
         [HttpGet("get-genres-by-{id}")]
         public async Task<IActionResult> GetGenreFromIdAsync(int id)
         {
             var result = await genresService.GetGenreFromIdAsync(id);
             return Ok(result);
         }
+
 
         [HttpDelete("soft-delete/{id}")]
         public async Task<IActionResult> SoftDeleteGenreAsync(int id)

--- a/GameLibraryAPI/GameLibraryAPI/Controllers/PublisherController.cs
+++ b/GameLibraryAPI/GameLibraryAPI/Controllers/PublisherController.cs
@@ -32,12 +32,22 @@ namespace GameLibrary.Api.Controllers
             });
         }
 
+
+        [HttpGet("get-publishers-filtered")]
+        public async Task<IActionResult> GetPublishersFilteredAsync([FromQuery] string? name = null, [FromQuery] string? sortOrder = "asc")
+        {
+            var result = await publisherService.GetPublishersFilteredAsync(name, sortOrder);
+            return Ok(result);
+        }
+
+
         [HttpGet("get-publishers-by-{id}")]
         public async Task<IActionResult> GetGenreFromIdAsync(int id)
         {
             var result = await publisherService.GetPublisherFromIdAsync(id);
             return Ok(result);
         }
+
 
         [HttpDelete("soft-delete/{id}")]
         public async Task<IActionResult> SoftDeleteGenreAsync(int id)


### PR DESCRIPTION
Introduced new service and repository methods to support filtering and sorting developers, genres, and publishers by name and order. Added corresponding API endpoints in DeveloperController, GenreController, and PublisherController to expose this functionality.